### PR TITLE
Break platform specific functionality of dvm-helper up

### DIFF
--- a/dvm-helper.386.go
+++ b/dvm-helper.386.go
@@ -1,0 +1,5 @@
+// +build 386
+
+package main
+
+const dockerArch string = "i386"

--- a/dvm-helper.amd64.go
+++ b/dvm-helper.amd64.go
@@ -1,0 +1,5 @@
+// +build amd64
+
+package main
+
+const dockerArch string = "x86_64"

--- a/dvm-helper.darwin.go
+++ b/dvm-helper.darwin.go
@@ -1,0 +1,5 @@
+// +build darwin
+
+package main
+
+const dockerOS string = "Darwin"

--- a/dvm-helper.go
+++ b/dvm-helper.go
@@ -11,6 +11,7 @@ import "path/filepath"
 import "regexp"
 import "sort"
 import "strings"
+import dvmPath "github.com/getcarina/dvm/path"
 import "github.com/fatih/color"
 import "github.com/google/go-github/github"
 import "github.com/codegangsta/cli"
@@ -488,9 +489,7 @@ func writeShellScript() {
 }
 
 func removePreviousDvmVersionFromPath() {
-	regex, _ := regexp.Compile(getCleanDvmPathRegex())
-	path := regex.ReplaceAllString(os.Getenv("PATH"), "")
-	os.Setenv("PATH", path)
+	dvmPath.Remove(getCleanDvmPathRegex())
 }
 
 func ensureVersionIsInstalled(version string) {

--- a/dvm-helper.linux.go
+++ b/dvm-helper.linux.go
@@ -1,0 +1,5 @@
+// +build linux
+
+package main
+
+const dockerOS string = "Linux"

--- a/dvm-helper.nix.go
+++ b/dvm-helper.nix.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const binaryFileExt string = ""
+
+func prependDvmVersionToPath(version string) {
+	versionDir := getVersionDir(version)
+	path := fmt.Sprintf("%s:%s", versionDir, os.Getenv("PATH"))
+	os.Setenv("PATH", path)
+}
+
+func getCleanDvmPathRegex() string {
+	return getVersionDir("") + `/(\d+\.\d+\.\d+|experimental):`
+}
+
+func validateShellFlag() {
+	// we don't care about the shell flag on non-Windows platforms
+}

--- a/dvm-helper.nix.go
+++ b/dvm-helper.nix.go
@@ -2,21 +2,11 @@
 
 package main
 
-import (
-	"fmt"
-	"os"
-)
-
 const binaryFileExt string = ""
 
-func prependDvmVersionToPath(version string) {
-	versionDir := getVersionDir(version)
-	path := fmt.Sprintf("%s:%s", versionDir, os.Getenv("PATH"))
-	os.Setenv("PATH", path)
-}
-
 func getCleanDvmPathRegex() string {
-	return getVersionDir("") + `/(\d+\.\d+\.\d+|experimental):`
+	versionDir := getVersionDir("")
+	return versionDir + `/(\d+\.\d+\.\d+|experimental):`
 }
 
 func validateShellFlag() {

--- a/dvm-helper.windows.go
+++ b/dvm-helper.windows.go
@@ -3,19 +3,11 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"strings"
 )
 
 const dockerOS string = "Windows"
 const binaryFileExt string = ".exe"
-
-func prependDvmVersionToPath(version string) {
-	versionDir := getVersionDir(version)
-	path := fmt.Sprintf("%s;%s", versionDir, os.Getenv("PATH"))
-	os.Setenv("PATH", path)
-}
 
 func getCleanDvmPathRegex() string {
 	versionDir := getVersionDir("")

--- a/dvm-helper.windows.go
+++ b/dvm-helper.windows.go
@@ -1,0 +1,30 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const dockerOS string = "Windows"
+const binaryFileExt string = ".exe"
+
+func prependDvmVersionToPath(version string) {
+	versionDir := getVersionDir(version)
+	path := fmt.Sprintf("%s;%s", versionDir, os.Getenv("PATH"))
+	os.Setenv("PATH", path)
+}
+
+func getCleanDvmPathRegex() string {
+	versionDir := getVersionDir("")
+	escapedVersionDir := strings.Replace(versionDir, `\`, `\\`, -1)
+	return escapedVersionDir + `\\(\d+\.\d+\.\d+|experimental);`
+}
+
+func validateShellFlag() {
+	if shell != "powershell" && shell != "cmd" {
+		die("The --shell flag or SHELL environment variable must be set when running on Windows. Available values are powershell and cmd.", nil, retCodeInvalidArgument)
+	}
+}

--- a/path/path.go
+++ b/path/path.go
@@ -1,0 +1,34 @@
+package path
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+const pathEnvVar string = "PATH"
+
+// Get the PATH environment variable value
+func Get() string {
+	return os.Getenv(pathEnvVar)
+}
+
+// Set the PATH environment variable value
+func Set(value string) {
+	os.Setenv(pathEnvVar, value)
+}
+
+// Prepend the specified value to the PATH environment variable
+func Prepend(value string) {
+	originalPath := Get()
+	newPath := fmt.Sprintf("%s%s%s", value, separator, originalPath)
+	Set(newPath)
+}
+
+// Remove any values which match the specified regular expression
+// from the PATH environment variable
+func Remove(regexValue string) {
+	regex, _ := regexp.Compile(regexValue)
+	newPath := regex.ReplaceAllString(Get(), "")
+	Set(newPath)
+}

--- a/path/path.nix.go
+++ b/path/path.nix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package path
+
+const separator string = ":"

--- a/path/path.windows.go
+++ b/path/path.windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package path
+
+const separator string = ";"


### PR DESCRIPTION
I've hunted down all usage of the `runtime` package and moved that logic into separate files based on the OS and ARCH.

In addition, I moved the path environment variable manipulation into a subpackage so that things are a bit more tidy.

Fixes #39 