### PR TITLE
Verify checksum of dvm-helper

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+# build - builds for the current OS and ARCH
+# build all - builds entire matrix
+
 cd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 get_commit() {
@@ -13,6 +17,17 @@ get_version() {
   VERSION=$(git describe --tags --dirty='-dev' 2> /dev/null)
   export VERSION
   return 0
+}
+
+build() {
+  # Detect the current OS and ARCH if not specified
+  [ -z "$1" ] && local GOOS=$(uname -s | tr '[:upper:]' '[:lower:]') || local GOOS=$1
+  [ -z "$2" ] && local GOARCH=$([ $(getconf LONG_BIT) == 64 ] && echo amd64 || echo 386) || local GOARCH=$2
+  [ "$GOOS" == "windows" ] && local FILE_EXT=".exe" || local FILE_EXT=""
+  local BINARY="dvm-helper-${GOOS}-${GOARCH}${FILE_EXT}"
+
+  go build -ldflags "${LDFLAGS}" -o bin/$BINARY
+  $(cd bin && shasum -a 256 $BINARY > $BINARY.sha256)
 }
 
 # Remove previously downloaded dvm-helper binaries
@@ -31,11 +46,13 @@ LDFLAGS="-X main.dvmCommit=${COMMIT} \
          -X main.dvmVersion=${VERSION}"
 
 # Build ALL THE THINGS!
-GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-windows-amd64.exe
-GOOS=windows GOARCH=386 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-windows-386.exe
-
-GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-darwin-amd64
-GOOS=darwin GOARCH=386 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-darwin-386
-
-GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-linux-amd64
-GOOS=linux GOARCH=386 go build -ldflags "${LDFLAGS}" -o bin/dvm-helper-linux-386
+if [ "$1" != "all" ]; then
+  build
+else
+  build windows amd64
+  build windows 386
+  build darwin amd64
+  build darwin 386
+  build linux amd64
+  build linux 386
+fi

--- a/dvm.ps1
+++ b/dvm.ps1
@@ -2,26 +2,47 @@
 # Implemented as a POSIX-compliant function
 # To use, source this script, `. dvm.ps1`, then type dvm help
 
-function downloadDvm()
-{
+function downloadDvm() {
   $dvmDir = $PSScriptRoot
   if( Test-Path (Join-Path $dvmDir dvm-helper.exe) ) {
     return
   }
 
+  $tmpDir = Join-Path $dvmDir .tmp
+  if( !(Test-Path $tmpDir) ) {
+    mkdir $tmpDir > $null
+  }
+
+  # Detect mac vs. linux and x86 vs. x64
   if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "amd64" } else { $arch = "386"}
+
+  # Download latest release
   $latestTag = (ConvertFrom-Json (wget https://api.github.com/repos/getcarina/dvm/tags).Content) | select -ExpandProperty name | select -first 1
-  (New-Object net.webclient).DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe", "$dvmDir\dvm-helper.exe")
+  $webClient = New-Object net.webclient
+  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
+  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
+
+  # Verify the binary was downloaded successfully
+  $checksum = (cat $tmpDir\dvm-helper-windows-$arch.exe.256).Split(' ')[0]
+  $hash = (Get-FileHash $tmpDir\dvm-helper-windows-$arch.exe).Hash
+  if([string]::Compare($checksum, $hash, $true) -ne 0) {
+    $host.ui.WriteErrorLine("DANGER! The downloaded dvm-helper binary, $tmpDir\dvm-helper-windows-$arch.exe, does not match its checksum!")
+    $host.ui.WriteErrorLine("CHECKSUM: $checksum")
+    $host.ui.WriteErrorLine("HASH: $hash")
+    return 1
+  }
+
+  mv "$tmpDir\dvm-helper-windows-$arch.exe" "$dvmDir\dvm-helper.exe"
 }
 
-function dvm()
-{
-  downloadDvm
+function dvm() {
+  if(downloadDvm -ne 0) {
+    return 1
+  }
 
   $dvmDir = $PSScriptRoot
   $dvmOutput = Join-Path $dvmDir .tmp\dvm-output.ps1
-  if( Test-Path $dvmOutput )
-  {
+  if( Test-Path $dvmOutput ) {
     rm $dvmOutput
   }
 
@@ -31,8 +52,7 @@ function dvm()
   $dvmCall = "$dvmDir\dvm-helper.exe --shell powershell $rawArgs"
   iex $dvmCall
 
-  if( Test-Path $dvmOutput )
-  {
+  if( Test-Path $dvmOutput ) {
     . $dvmOutput
   }
 }

--- a/dvm.sh
+++ b/dvm.sh
@@ -6,16 +6,31 @@
 # To use, source this file from your bash profile
 
 dvm() {
-  DVM_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+  local DVM_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
   if [ ! -f "${DVM_DIR}/dvm-helper" ]; then
     # Detect mac vs. linux and x86 vs. x64
     DVM_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     [ $(getconf LONG_BIT) == 64 ] && DVM_ARCH="amd64" || DVM_ARCH="386"
 
+    local TMP_DIR="$DVM_DIR/.tmp"
+    if [ ! -d $TMP_DIR ]; then
+      mkdir $TMP_DIR
+    fi
+
     # Download latest release
     LATEST_TAG=$(curl -s https://api.github.com/repos/getcarina/dvm/tags | grep name -m 1 | awk '{print $2}' | cut -d '"' -f2)
-    curl -L -s -o $DVM_DIR/dvm-helper https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH
+    curl -L -s -o $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH
+    curl -L -s -o $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH.sha256 https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH.sha256
+
+    # Verify the binary was downloaded successfully
+    $(cd $TMP_DIR && shasum -c dvm-helper-$DVM_OS-$DVM_ARCH.sha256 > /dev/null 2>&1)
+    if [ $? -ne 0 ]; then
+      echo "DANGER! The downloaded dvm-helper binary, $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH, does not match its checksum!"
+      return 1
+    fi
+
+    mv $DVM_DIR/.tmp/dvm-helper-$DVM_OS-$DVM_ARCH $DVM_DIR/dvm-helper
     chmod u+x $DVM_DIR/dvm-helper
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 { # this ensures the entire script is downloaded #
 


### PR DESCRIPTION
Generate *.sha256 files for each binary during the build.

I've also updated the build script so that we can either build for the current platform (default), or build everything with `./build all`.

Fixes #34 