### PR TITLE
Download dvm helper during install

### DIFF
--- a/dvm.cmd
+++ b/dvm.cmd
@@ -7,19 +7,20 @@ SETLOCAL
 
 SET DVM_DIR=%~dp0
 
-IF NOT EXIST dvm-helper.exe (
-  CALL powershell ". dvm.ps1; downloadDvm"
+IF NOT EXIST "%DVM_DIR%\dvm-helper.exe" (
+  echo Installation corrupt: dvm-helper.exe is missing. Please reinstall dvm.
+  EXIT /b 1
 )
 
-SET DVM_OUTPUT=%DVM_DIR%\.tmp\dvm-output.cmd
+SET DVM_OUTPUT="%DVM_DIR%\.tmp\dvm-output.cmd"
 
-IF EXIST %DVM_OUTPUT% (
-  DEL %DVM_OUTPUT%
+IF EXIST "%DVM_OUTPUT%" (
+  DEL "%DVM_OUTPUT%"
 )
 
 %DVM_DIR%\dvm-helper.exe --shell cmd %*
 
-IF EXIST %DVM_OUTPUT% (
+IF EXIST "%DVM_OUTPUT%" (
   ENDLOCAL
-  CALL %DVM_OUTPUT%
+  CALL "%DVM_OUTPUT%"
 )

--- a/dvm.ps1
+++ b/dvm.ps1
@@ -2,45 +2,14 @@
 # Implemented as a POSIX-compliant function
 # To use, source this script, `. dvm.ps1`, then type dvm help
 
-function downloadDvm() {
-  $dvmDir = $PSScriptRoot
-  if( Test-Path (Join-Path $dvmDir dvm-helper.exe) ) {
-    return
-  }
-
-  $tmpDir = Join-Path $dvmDir .tmp
-  if( !(Test-Path $tmpDir) ) {
-    mkdir $tmpDir > $null
-  }
-
-  # Detect mac vs. linux and x86 vs. x64
-  if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "amd64" } else { $arch = "386"}
-
-  # Download latest release
-  $latestTag = (ConvertFrom-Json (wget https://api.github.com/repos/getcarina/dvm/tags).Content) | select -ExpandProperty name | select -first 1
-  $webClient = New-Object net.webclient
-  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
-  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
-
-  # Verify the binary was downloaded successfully
-  $checksum = (cat $tmpDir\dvm-helper-windows-$arch.exe.256).Split(' ')[0]
-  $hash = (Get-FileHash $tmpDir\dvm-helper-windows-$arch.exe).Hash
-  if([string]::Compare($checksum, $hash, $true) -ne 0) {
-    $host.ui.WriteErrorLine("DANGER! The downloaded dvm-helper binary, $tmpDir\dvm-helper-windows-$arch.exe, does not match its checksum!")
-    $host.ui.WriteErrorLine("CHECKSUM: $checksum")
-    $host.ui.WriteErrorLine("HASH: $hash")
-    return 1
-  }
-
-  mv "$tmpDir\dvm-helper-windows-$arch.exe" "$dvmDir\dvm-helper.exe"
-}
-
 function dvm() {
-  if(downloadDvm -ne 0) {
+  $dvmDir = $PSScriptRoot
+
+  if( !(Test-Path (Join-Path $dvmDir dvm-helper.exe)) ) {
+    $host.ui.WriteErrorLine("Installation corrupt: dvm-helper.exe is missing. Please reinstall dvm.")
     return 1
   }
 
-  $dvmDir = $PSScriptRoot
   $dvmOutput = Join-Path $dvmDir .tmp\dvm-output.ps1
   if( Test-Path $dvmOutput ) {
     rm $dvmOutput

--- a/dvm.sh
+++ b/dvm.sh
@@ -9,29 +9,8 @@ dvm() {
   local DVM_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
   if [ ! -f "${DVM_DIR}/dvm-helper" ]; then
-    # Detect mac vs. linux and x86 vs. x64
-    DVM_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-    [ $(getconf LONG_BIT) == 64 ] && DVM_ARCH="amd64" || DVM_ARCH="386"
-
-    local TMP_DIR="$DVM_DIR/.tmp"
-    if [ ! -d $TMP_DIR ]; then
-      mkdir $TMP_DIR
-    fi
-
-    # Download latest release
-    LATEST_TAG=$(curl -s https://api.github.com/repos/getcarina/dvm/tags | grep name -m 1 | awk '{print $2}' | cut -d '"' -f2)
-    curl -L -s -o $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH
-    curl -L -s -o $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH.sha256 https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH.sha256
-
-    # Verify the binary was downloaded successfully
-    $(cd $TMP_DIR && shasum -c dvm-helper-$DVM_OS-$DVM_ARCH.sha256 > /dev/null 2>&1)
-    if [ $? -ne 0 ]; then
-      echo "DANGER! The downloaded dvm-helper binary, $TMP_DIR/dvm-helper-$DVM_OS-$DVM_ARCH, does not match its checksum!"
-      return 1
-    fi
-
-    mv $DVM_DIR/.tmp/dvm-helper-$DVM_OS-$DVM_ARCH $DVM_DIR/dvm-helper
-    chmod u+x $DVM_DIR/dvm-helper
+    echo "Installation corrupt: dvm-helper is missing. Please reinstall dvm."
+    return 1
   fi
 
   DVM_OUTPUT="${DVM_DIR}/.tmp/dvm-output.sh"

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,42 @@
 $ErrorActionPreference = "Stop"
 
+function downloadDvm([string] $dvmDir) {
+  $webClient = New-Object net.webclient
+
+  echo "Downloading dvm.ps1..."
+  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.ps1", "$dvmDir\dvm.ps1")
+
+  echo "Downloading dvm.cmd..."
+  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.cmd", "$dvmDir\dvm.cmd")
+
+  echo "Downloading dvm-helper.exe..."
+  $tmpDir = Join-Path $dvmDir .tmp
+  if( !(Test-Path $tmpDir) ) {
+    mkdir $tmpDir > $null
+  }
+
+  # Detect x86 vs. x64
+  if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "amd64" } else { $arch = "386"}
+
+  # Download latest release
+  $latestTag = (ConvertFrom-Json (wget https://api.github.com/repos/getcarina/dvm/tags).Content) | select -ExpandProperty name | select -first 1
+
+  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
+  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
+
+  # Verify the binary was downloaded successfully
+  $checksum = (cat $tmpDir\dvm-helper-windows-$arch.exe.256).Split(' ')[0]
+  $hash = (Get-FileHash $tmpDir\dvm-helper-windows-$arch.exe).Hash
+  if([string]::Compare($checksum, $hash, $true) -ne 0) {
+    $host.ui.WriteErrorLine("DANGER! The downloaded dvm-helper binary, $tmpDir\dvm-helper-windows-$arch.exe, does not match its checksum!")
+    $host.ui.WriteErrorLine("CHECKSUM: $checksum")
+    $host.ui.WriteErrorLine("HASH: $hash")
+    return 1
+  }
+
+  mv "$tmpDir\dvm-helper-windows-$arch.exe" "$dvmDir\dvm-helper.exe"
+}
+
 function installDvm()
 {
   $dvmDir = $env:DVM_DIR
@@ -11,13 +48,7 @@ function installDvm()
     mkdir $dvmDir > $null
   }
 
-  $webClient = New-Object net.webclient
-
-  echo "Downloading dvm.ps1..."
-  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.ps1", "$dvmDir\dvm.ps1")
-
-  echo "Downloading dvm.cmd..."
-  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.cmd", "$dvmDir\dvm.cmd")
+  downloadDvm $dvmDir
 
   echo "Docker Version Manager (dvm) has been installed to $dvmDir"
   echo ""

--- a/install.ps1
+++ b/install.ps1
@@ -50,14 +50,15 @@ function installDvm()
 
   downloadDvm $dvmDir
 
+  echo ""
   echo "Docker Version Manager (dvm) has been installed to $dvmDir"
   echo ""
-  echo "PowerShell Users: Add the following command to your PowerShell profile:"
+  echo "PowerShell Users: Run the following command to start using dvm. Then add it to your PowerShell profile to complete the installation."
   echo "`t. $dvmDir\dvm.ps1"
   echo ""
-  echo "CMD Users: Run the following commands to add dvm.cmd to your PATH:"
-  echo "`tPATH=%PATH%;$dvmDir"
-  echo "`tsetx PATH `"%PATH%;$dvmDir`""
+  echo "CMD Users: Run the first command to start using dvm. Then run the second command to add dvm to your PATH to complete the installation."
+  echo "`t1. PATH=%PATH%;$dvmDir"
+  echo "`t2. setx PATH `"%PATH%;$dvmDir`""
 }
 
 installDvm

--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,8 @@ fi
 echo "Downloading dvm.sh..."
 dvm_download -L -C - --progress-bar https://raw.githubusercontent.com/getcarina/dvm/master/dvm.sh -o $DVM_DIR/dvm.sh
 
-if [ ! -f "${DVM_DIR}/dvm-helper" ]; then
-  echo "Downloading dvm-helper..."
-  install_dvm_helper
-fi
+echo "Downloading dvm-helper..."
+install_dvm_helper
 
 echo ""
 echo "Docker Version Manager (dvm) has been installed to ${DVM_DIR}"

--- a/install.sh
+++ b/install.sh
@@ -78,8 +78,9 @@ if [ ! -f "${DVM_DIR}/dvm-helper" ]; then
   install_dvm_helper
 fi
 
+echo ""
 echo "Docker Version Manager (dvm) has been installed to ${DVM_DIR}"
-echo "Add the following command to your bash profile (e.g. ~/.bashrc or ~/.bash_profile) to complete the installation:"
+echo "Run the following command to start using dvm. Then add it to your bash profile (e.g. ~/.bashrc or ~/.bash_profile) to complete the installation."
 echo ""
 echo "\tsource ${DVM_DIR}/dvm.sh"
 


### PR DESCRIPTION
* Updated all install and wrapper scripts to move downloading dvm-help to install. If dvm-helper is missing when the user runs `dvm`, a message is printed that they need to reinstall.
* Fixed `install.sh` so that the latest version of dvm-helper is always installed.
* Tweaked post-install output based on user feedback.
