### PR TITLE
Streamline release process

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,6 @@
+FROM golang:1.5
+
+ADD . $GOPATH/src/github.com/getcarina/dvm/
+WORKDIR $GOPATH/src/github.com/getcarina/dvm/
+
+RUN make get-deps

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ dvm-helper: get-deps $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o dvm-helper/dvm-helper $(PACKAGE)
 
 linux: $(GOFILES)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o bin/linux/x86_64/dvm-helper $(PACKAGE)
-	cd bin/linux/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o bin/Linux/x86_64/dvm-helper $(PACKAGE)
+	cd bin/Linux/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
 
 darwin: $(GOFILES)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/darwin/x86_64/dvm-helper $(PACKAGE)
-	cd bin/darwin/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/Darwin/x86_64/dvm-helper $(PACKAGE)
+	cd bin/Darwin/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
 
 windows: $(GOFILES)
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o bin/windows/x86_64/dvm-helper.exe $(PACKAGE)
-	cd bin/windows/x86_64 && shasum -a 256 dvm-helper.exe > dvm-helper.exe.sha256
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o bin/Windows/x86_64/dvm-helper.exe $(PACKAGE)
+	cd bin/Windows/x86_64 && shasum -a 256 dvm-helper.exe > dvm-helper.exe.sha256
 
 ############################ RELEASE TARGETS ############################
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+COMMIT = $(shell git rev-parse --verify --short HEAD)
+VERSION = $(shell git describe --tags --dirty='-dev' 2> /dev/null)
+GITHUB_ORG = getcarina
+GITHUB_REPO = dvm
+PACKAGE = github.com/${GITHUB_ORG}/${GITHUB_REPO}/dvm-helper
+
+LDFLAGS = -w -X main.dvmCommit=${COMMIT} -X main.dvmVersion=${VERSION}
+
+GOCMD = go
+GOBUILD = $(GOCMD) build -a -tags netgo -ldflags '$(LDFLAGS)'
+
+GOFILES = dvm-helper/*.go
+
+default: dvm-helper
+
+get-deps:
+	go get ./...
+
+#test: dvm-helper
+#	go test -v
+#	eval "$( ./dvm-helper --bash-completion )"
+#	./dvm-helper --version
+
+cross-build: get-deps dvm-helper linux darwin windows
+
+dvm-helper: get-deps $(GOFILES)
+	CGO_ENABLED=0 $(GOBUILD) -o dvm-helper/dvm-helper $(PACKAGE)
+
+linux: $(GOFILES)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-linux-amd64 $(PACKAGE)
+	cd bin && shasum -a 256 dvm-helper-linux-amd64 > dvm-helper-linux-amd64.sha256
+
+darwin: $(GOFILES)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-darwin-amd64 $(PACKAGE)
+	cd bin && shasum -a 256 dvm-helper-darwin-amd64 > dvm-helper-darwin-amd64.sha256
+
+windows: $(GOFILES)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-windows-amd64.exe $(PACKAGE)
+	cd bin && shasum -a 256 dvm-helper-windows-amd64.exe > dvm-helper-windows-amd64.exe.sha256
+
+############################ RELEASE TARGETS ############################
+
+build-tagged-for-release: clean
+	-docker rm -fv dvm-helper-build
+	docker build -f Dockerfile.build -t dvm-helper-cli-build --no-cache=true .
+	docker run --name dvm-helper-build dvm-helper-cli-build make tagged-build TAG=$(TAG)
+	mkdir -p bin/
+	docker cp dvm-helper-build:/built/bin .
+
+checkout-tag:
+	git checkout $(TAG)
+
+# This one is intended to be run inside the accompanying Docker container
+tagged-build: checkout-tag cross-build
+	./dvm-helper --version
+	mkdir -p /built/
+	cp -r bin /built/bin
+
+.PHONY: clean build-tagged-for-release checkout tagged-build
+
+clean:
+	 -rm -f bin/*
+	 -rm dvm-helper/dvm-helper
+	 -rm dvm-helper/dvm-helper.exe

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ dvm-helper: get-deps $(GOFILES)
 	CGO_ENABLED=0 $(GOBUILD) -o dvm-helper/dvm-helper $(PACKAGE)
 
 linux: $(GOFILES)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-linux-amd64 $(PACKAGE)
-	cd bin && shasum -a 256 dvm-helper-linux-amd64 > dvm-helper-linux-amd64.sha256
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o bin/linux/x86_64/dvm-helper $(PACKAGE)
+	cd bin/linux/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
 
 darwin: $(GOFILES)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-darwin-amd64 $(PACKAGE)
-	cd bin && shasum -a 256 dvm-helper-darwin-amd64 > dvm-helper-darwin-amd64.sha256
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/darwin/x86_64/dvm-helper $(PACKAGE)
+	cd bin/darwin/x86_64 && shasum -a 256 dvm-helper > dvm-helper.sha256
 
 windows: $(GOFILES)
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o bin/dvm-helper-windows-amd64.exe $(PACKAGE)
-	cd bin && shasum -a 256 dvm-helper-windows-amd64.exe > dvm-helper-windows-amd64.exe.sha256
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(GOBUILD) -o bin/windows/x86_64/dvm-helper.exe $(PACKAGE)
+	cd bin/windows/x86_64 && shasum -a 256 dvm-helper.exe > dvm-helper.exe.sha256
 
 ############################ RELEASE TARGETS ############################
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ checkout-tag:
 
 # This one is intended to be run inside the accompanying Docker container
 tagged-build: checkout-tag cross-build
-	./dvm-helper --version
+	dvm-helper/dvm-helper --version
 	mkdir -p /built/
 	cp -r bin /built/bin
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mac OS X and Linux require curl or wget.
 **Mac OS X and Linux**
 
 ```bash
-$ curl -s https://download.getcarina.com/getcarina/dvm/latest/install.sh | sh
+$ curl -s https://download.getcarina.com/dvm/latest/install.sh | sh
 ```
 
 **Windows**
@@ -32,7 +32,7 @@ Open a PowerShell command prompt and execute the following command. We use Power
 installation but you can use `dvm` with PowerShell or CMD once it's installed.
 
 ```powershell
-> iex (wget https://download.getcarina.com/getcarina/dvm/latest/install.ps1)
+> iex (wget https://download.getcarina.com/dvm/latest/install.ps1)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mac OS X and Linux require curl or wget.
 **Mac OS X and Linux**
 
 ```bash
-$ curl -s https://raw.githubusercontent.com/getcarina/dvm/master/install.sh | sh
+$ curl -s https://download.getcarina.com/getcarina/dvm/latest/install.sh | sh
 ```
 
 **Windows**
@@ -32,7 +32,7 @@ Open a PowerShell command prompt and execute the following command. We use Power
 installation but you can use `dvm` with PowerShell or CMD once it's installed.
 
 ```powershell
-> iex (wget https://raw.githubusercontent.com/getcarina/dvm/master/install.ps1)
+> iex (wget https://download.getcarina.com/getcarina/dvm/latest/install.ps1)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mac OS X and Linux require curl or wget.
 **Mac OS X and Linux**
 
 ```bash
-$ curl -s https://download.getcarina.com/dvm/latest/install.sh | sh
+$ curl -s -L https://download.getcarina.com/dvm/latest/install.sh | sh
 ```
 
 **Windows**

--- a/install.ps1
+++ b/install.ps1
@@ -4,10 +4,10 @@ function downloadDvm([string] $dvmDir) {
   $webClient = New-Object net.webclient
 
   echo "Downloading dvm.ps1..."
-  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.ps1", "$dvmDir\dvm.ps1")
+  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm.ps1", "$dvmDir\dvm.ps1")
 
   echo "Downloading dvm.cmd..."
-  $webClient.DownloadFile("https://raw.githubusercontent.com/getcarina/dvm/master/dvm.cmd", "$dvmDir\dvm.cmd")
+  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm.cmd", "$dvmDir\dvm.cmd")
 
   echo "Downloading dvm-helper.exe..."
   $tmpDir = Join-Path $dvmDir .tmp
@@ -26,10 +26,8 @@ function downloadDvm([string] $dvmDir) {
   if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "amd64" } else { $arch = "386"}
 
   # Download latest release
-  $latestTag = (ConvertFrom-Json (wget https://api.github.com/repos/getcarina/dvm/tags).Content) | select -ExpandProperty name | select -first 1
-
-  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
-  $webClient.DownloadFile("https://github.com/getcarina/dvm/releases/download/$latestTag/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
+  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
+  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
 
   # Verify the binary was downloaded successfully
   $checksum = (cat $tmpDir\dvm-helper-windows-$arch.exe.256).Split(' ')[0]

--- a/install.ps1
+++ b/install.ps1
@@ -26,8 +26,8 @@ function downloadDvm([string] $dvmDir) {
   if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "x86_64" } else { $arch = "i386"}
 
   # Download latest release
-  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/windows/$arch/dvm-helper.exe", "$tmpDir\dvm-helper.exe")
-  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/windows/$arch/dvm-helper.exe.sha256", "$tmpDir\dvm-helper.exe.256")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/Windows/$arch/dvm-helper.exe", "$tmpDir\dvm-helper.exe")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/Windows/$arch/dvm-helper.exe.sha256", "$tmpDir\dvm-helper.exe.256")
 
   # Verify the binary was downloaded successfully
   $checksum = (cat $tmpDir\dvm-helper.exe.256).Split(' ')[0]

--- a/install.ps1
+++ b/install.ps1
@@ -4,10 +4,10 @@ function downloadDvm([string] $dvmDir) {
   $webClient = New-Object net.webclient
 
   echo "Downloading dvm.ps1..."
-  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm.ps1", "$dvmDir\dvm.ps1")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/dvm.ps1", "$dvmDir\dvm.ps1")
 
   echo "Downloading dvm.cmd..."
-  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm.cmd", "$dvmDir\dvm.cmd")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/dvm.cmd", "$dvmDir\dvm.cmd")
 
   echo "Downloading dvm-helper.exe..."
   $tmpDir = Join-Path $dvmDir .tmp
@@ -26,20 +26,20 @@ function downloadDvm([string] $dvmDir) {
   if( [System.Environment]::Is64BitOperatingSystem ) { $arch = "amd64" } else { $arch = "386"}
 
   # Download latest release
-  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-windows-$arch.exe", "$tmpDir\dvm-helper-windows-$arch.exe")
-  $webClient.DownloadFile("https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-windows-$arch.exe.sha256", "$tmpDir\dvm-helper-windows-$arch.exe.256")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/windows/$arch/dvm-helper.exe", "$tmpDir\dvm-helper.exe")
+  $webClient.DownloadFile("https://download.getcarina.com/dvm/latest/windows/$arch/dvm-helper.exe.sha256", "$tmpDir\dvm-helper.exe.256")
 
   # Verify the binary was downloaded successfully
-  $checksum = (cat $tmpDir\dvm-helper-windows-$arch.exe.256).Split(' ')[0]
-  $hash = (Get-FileHash $tmpDir\dvm-helper-windows-$arch.exe).Hash
+  $checksum = (cat $tmpDir\dvm-helper.exe.256).Split(' ')[0]
+  $hash = (Get-FileHash $tmpDir\dvm-helper.exe).Hash
   if([string]::Compare($checksum, $hash, $true) -ne 0) {
-    $host.ui.WriteErrorLine("DANGER! The downloaded dvm-helper binary, $tmpDir\dvm-helper-windows-$arch.exe, does not match its checksum!")
+    $host.ui.WriteErrorLine("DANGER! The downloaded dvm-helper binary, $tmpDir\dvm-helper.exe, does not match its checksum!")
     $host.ui.WriteErrorLine("CHECKSUM: $checksum")
     $host.ui.WriteErrorLine("HASH: $hash")
     return 1
   }
 
-  mv "$tmpDir\dvm-helper-windows-$arch.exe" "$dvmDir\dvm-helper\dvm-helper.exe"
+  mv "$tmpDir\dvm-helper.exe" "$dvmDir\dvm-helper\dvm-helper.exe"
 }
 
 function installDvm()

--- a/install.ps1
+++ b/install.ps1
@@ -39,7 +39,7 @@ function downloadDvm([string] $dvmDir) {
     return 1
   }
 
-  mv "$tmpDir\dvm-helper.exe" "$dvmDir\dvm-helper\dvm-helper.exe"
+  mv -force "$tmpDir\dvm-helper.exe" "$dvmDir\dvm-helper\dvm-helper.exe"
 }
 
 function installDvm()

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ install_dvm_helper() {
   # Download latest release
   mkdir -p "$DVM_DIR/dvm-helper"
   bin="$DVM_DIR/dvm-helper/dvm-helper"
-  url=https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-$DVM_OS-$DVM_ARCH
+  url=https://download.getcarina.com/dvm/latest/$DVM_OS/$DVM_ARCH/dvm-helper
   dvm_download -L -C - --progress-bar $url -o "$bin"
   chmod u+x $bin
 }
@@ -71,7 +71,7 @@ if [ ! -d "$DVM_DIR" ]; then
 fi
 
 echo "Downloading dvm.sh..."
-dvm_download -L -C - --progress-bar https://download.getcarina.com/getcarina/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
+dvm_download -L -C - --progress-bar https://download.getcarina.com/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
 
 echo "Downloading dvm-helper..."
 install_dvm_helper

--- a/install.sh
+++ b/install.sh
@@ -54,10 +54,9 @@ install_dvm_helper() {
   [ $(getconf LONG_BIT) == 64 ] && DVM_ARCH="amd64" || DVM_ARCH="386"
 
   # Download latest release
-  LATEST_TAG=$(curl -s https://api.github.com/repos/getcarina/dvm/tags | grep name -m 1 | awk '{print $2}' | cut -d '"' -f2)
   mkdir -p "$DVM_DIR/dvm-helper"
   bin="$DVM_DIR/dvm-helper/dvm-helper"
-  url=https://github.com/getcarina/dvm/releases/download/$LATEST_TAG/dvm-helper-$DVM_OS-$DVM_ARCH
+  url=https://download.getcarina.com/getcarina/dvm/latest/dvm-helper-$DVM_OS-$DVM_ARCH
   dvm_download -L -C - --progress-bar $url -o "$bin"
   chmod u+x $bin
 }
@@ -72,7 +71,7 @@ if [ ! -d "$DVM_DIR" ]; then
 fi
 
 echo "Downloading dvm.sh..."
-dvm_download -L -C - --progress-bar https://raw.githubusercontent.com/getcarina/dvm/master/dvm.sh -o $DVM_DIR/dvm.sh
+dvm_download -L -C - --progress-bar https://download.getcarina.com/getcarina/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
 
 echo "Downloading dvm-helper..."
 install_dvm_helper

--- a/install.sh
+++ b/install.sh
@@ -39,8 +39,7 @@ dvm_download() {
                            -e 's/-L //' \
                            -e 's/-I /--server-response /' \
                            -e 's/-s /-q /' \
-                           -e 's/-o /-O /' \
-                           -e 's/-C - /-c /')
+                           -e 's/-o /-O /')
     eval wget $ARGS
   fi
 }
@@ -57,7 +56,7 @@ install_dvm_helper() {
   mkdir -p "$DVM_DIR/dvm-helper"
   bin="$DVM_DIR/dvm-helper/dvm-helper"
   url=https://download.getcarina.com/dvm/latest/$DVM_OS/$DVM_ARCH/dvm-helper
-  dvm_download -L -C - --progress-bar $url -o "$bin"
+  dvm_download -L --progress-bar $url -o "$bin"
   chmod u+x $bin
 }
 
@@ -71,7 +70,7 @@ if [ ! -d "$DVM_DIR" ]; then
 fi
 
 echo "Downloading dvm.sh..."
-dvm_download -L -C - --progress-bar https://download.getcarina.com/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
+dvm_download -L --progress-bar https://download.getcarina.com/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
 
 echo "Downloading dvm-helper..."
 install_dvm_helper

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -xr ORG="carolynvs" # TODO: getcarina
+declare -xr ORG="getcarina"
 declare -xr REPO="dvm"
 declare -xr BINARY="dvm-helper"
 declare -xr DESCRIPTION="The Docker Version Manager (dvm)"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -xr ORG="carolynvs" # TODO: getcarina
+declare -xr REPO="dvm"
+declare -xr BINARY="dvm-helper"
+declare -xr DESCRIPTION="The Docker Version Manager (dvm)"
+
+function usage {
+  echo 'usage: release.sh "{major}.{minor}.{patch}"'
+}
+
+function main {
+  # Pick your own leveled up tag
+  TAG=${1:-}
+  NAME=$TAG
+
+  if [ "$TAG" == "" ] || [ "$NAME" == "" ] || [ "${TAG:0:1}" == "v" ]; then
+    usage
+    exit 5
+  fi
+
+
+  echo "Releasing '$TAG' : $DESCRIPTION"
+
+
+  if [ ! -e "$( which github-release )" ]; then
+    echo "You need github-release installed."
+    echo "go get github.com/aktau/github-release"
+    exit 1
+  fi
+
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
+
+  if [ "$BRANCH" != "master" ]; then
+    echo "Must release from master branch"
+    exit 2
+  fi
+
+  set +e
+  git diff --exit-code > /dev/null
+  if [ $? != 0 ]; then
+    echo "Workspace is not clean. Exiting"
+    exit 3
+  fi
+  set -e
+
+  REMOTE="release"
+  REMOTE_URL="git@github.com:${ORG}/${REPO}.git"
+
+  #
+  # Confirm that we have a remote named "release"
+  #
+
+  set +e
+  git remote show ${REMOTE} &> /dev/null
+
+  rc=$?
+
+  if [[ $rc != 0 ]]; then
+    echo "Remote \"${REMOTE}\" not found. Exiting."
+    exit 4
+  fi
+  set -e
+
+  #
+  # Now confirm that we've got the proper remote URL
+  #
+
+  REMOTE_ACTUAL_URL=$(git remote show ${REMOTE} | grep Push | cut -d ":" -f2- | xargs)
+
+  if [ "$REMOTE_URL" != "$REMOTE_ACTUAL_URL" ]; then
+    echo -e "Remote \"${REMOTE}\" PUSH url incorrect.\nShould be ${REMOTE_URL}. Exiting."
+    exit 5
+  fi
+
+  make clean
+  # Build off master to make sure all is well
+  make dvm-helper
+  echo "Out with the old, in with the new"
+  ./dvm-helper/dvm-helper --version
+  echo "---------------------------------"
+
+  # Build with the tag now for actual binary shipping
+  git fetch --tags $REMOTE
+  make build-tagged-for-release TAG=$TAG
+
+  echo "Creating a new relase on GitHub..."
+  github-release release \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "$NAME" \
+    --description "$DESCRIPTION"
+
+  push_binaries
+  push_scripts
+}
+
+function push_binaries {
+  for file in bin/${BINARY}-*; do
+    github-release upload \
+      --user "$ORG" \
+      --repo "$REPO" \
+      --tag "$TAG" \
+      --name "$(basename $file)" \
+      --file "$file"
+  done
+}
+
+function push_scripts {
+  github-release upload \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "dvm.sh" \
+    --file "dvm.sh"
+
+  github-release upload \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "dvm.cmd" \
+    --file "dvm.cmd"
+
+  github-release upload \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "dvm.ps1" \
+    --file "dvm.ps1"
+
+  github-release upload \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "install.ps1" \
+    --file "install.ps1"
+
+  github-release upload \
+    --user "$ORG" \
+    --repo "$REPO" \
+    --tag "$TAG" \
+    --name "install.sh" \
+    --file "install.sh"
+}
+
+main "$1"


### PR DESCRIPTION
- [x] Fixes #56 (Release shell scripts to the releases page)
- [x] Fixes #51 (Download latest release, not latest tag)
- [x] Fixes #36 (Automate release using github-release)
- [ ] Upload release artifacts to cloud files instead of github release page

**Build and Test Process**
Use `make` to build and output to `dvm-helper/dvm-helper`. Use `make cross-build` to build all platforms (then manually copy the desired binary from the repo-path/bin).

**Release Process**
1. `git checkout master`
2. `git pull`
3. `git tag 0.2.0 -a -m ""`.
4. `git push --follow-tags`
5. `./release.sh 0.2.0`