### PR TITLE
Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Mac OS X and Linux require curl or wget.
 **Mac OS X and Linux**
 
 ```bash
-$ curl -s -L https://download.getcarina.com/dvm/latest/install.sh | sh
+$ curl -sL https://download.getcarina.com/dvm/latest/install.sh | sh
 ```
 
 **Windows**
@@ -36,8 +36,10 @@ installation but you can use `dvm` with PowerShell or CMD once it's installed.
 ```
 
 ## Upgrading from previous dvm
+If you have dvm 0.2 or later, run `dvm upgrade` to install the latest version of dvm.
 
-`dvm` used to *only* be only one shell script, relying on a git backed `~/.dvm`. This worked well for \*nix users and was not workable for Windows users. We've since switched over to small wrapper scripts and a go binary called `dvm-helper` to make cross platform simple and easy. To upgrade, you can either pull and rebuild yourself (with a working go setup), or use the install script. You'll need to open up a new terminal to ensure that all the `dvm` functions are set properly.
+If you have dvm 0.0.0, then you will need to reinstall. `dvm` used to *only* be only one shell script, relying on a git backed `~/.dvm`. This worked well for \*nix users and was not workable for Windows users. We've since switched over to small wrapper scripts and a go binary called `dvm-helper` to make cross platform simple and easy. To upgrade, you can either pull and rebuild yourself (with a working go setup), or use the install script. You'll need to open up a new terminal to ensure that all the `dvm` functions are set properly.
+
 
 ## Usage
 

--- a/dvm-helper/dvm-helper.386.go
+++ b/dvm-helper/dvm-helper.386.go
@@ -3,3 +3,4 @@
 package main
 
 const dockerArch string = "i386"
+const dvmArch string = "i386"

--- a/dvm-helper/dvm-helper.amd64.go
+++ b/dvm-helper/dvm-helper.amd64.go
@@ -3,3 +3,4 @@
 package main
 
 const dockerArch string = "x86_64"
+const dvmArch string = "x86_64"

--- a/dvm-helper/dvm-helper.darwin.go
+++ b/dvm-helper/dvm-helper.darwin.go
@@ -3,3 +3,4 @@
 package main
 
 const dockerOS string = "Darwin"
+const dvmOS string = "Darwin"

--- a/dvm-helper/dvm-helper.linux.go
+++ b/dvm-helper/dvm-helper.linux.go
@@ -3,3 +3,4 @@
 package main
 
 const dockerOS string = "Linux"
+const dvmOS string = "Linux"

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -2,7 +2,19 @@
 
 package main
 
+import "path/filepath"
+
 const binaryFileExt string = ""
+
+func upgradeSelf(version string) {
+	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")
+	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper")
+	downloadFileWithChecksum(binaryURL, binaryPath)
+
+	scriptURL := buildDvmReleaseURL(version, "dvm.sh")
+	scriptPath := filepath.Join(dvmDir, "dvm.sh")
+	downloadFile(scriptURL, scriptPath)
+}
 
 func getCleanDvmPathRegex() string {
 	versionDir := getVersionDir("")

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -2,12 +2,44 @@
 
 package main
 
-import (
-	"strings"
-)
+import "fmt"
+import "path/filepath"
+import "strings"
 
 const dockerOS string = "Windows"
+const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
+
+func upgradeSelf(version string) {
+	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")
+	binaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")
+	downloadFileWithChecksum(binaryURL, binaryPath)
+
+	psScriptURL := buildDvmReleaseURL(version, "dvm.ps1")
+	psScriptPath := filepath.Join(dvmDir, "dvm.ps1")
+	downloadFile(psScriptURL, psScriptPath)
+
+	cmdScriptURL := buildDvmReleaseURL(version, "dvm.cmd")
+	cmdScriptPath := filepath.Join(dvmDir, "dvm.cmd")
+	downloadFile(cmdScriptURL, cmdScriptPath)
+
+	writeUpgradeScript()
+}
+
+func writeUpgradeScript() {
+	scriptPath := buildDvmOutputScriptPath()
+	tmpBinaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")
+	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper.exe")
+
+	var contents string
+	if shell == "powershell" {
+		contents = fmt.Sprintf("cp -force %s %s", tmpBinaryPath, binaryPath)
+	} else { // cmd
+		contents = fmt.Sprintf("cp /Y %s %s", tmpBinaryPath, binaryPath)
+	}
+
+	writeFile(scriptPath, contents)
+}
 
 func getCleanDvmPathRegex() string {
 	versionDir := getVersionDir("")

--- a/dvm-helper/path.go
+++ b/dvm-helper/path.go
@@ -32,3 +32,19 @@ func removePath(regexValue string) {
 	newPath := regex.ReplaceAllString(getPath(), "")
 	setPath(newPath)
 }
+
+// Build a script which sets the PATH environment variable
+func buildPathScript() string {
+	path := getPath()
+
+	if shell == "powershell" {
+		return fmt.Sprintf(`$env:PATH="%s"`, path)
+	}
+
+	if shell == "cmd" {
+		return fmt.Sprintf("PATH=%s", path)
+	}
+
+	// default to bash
+	return fmt.Sprintf(`export PATH="%s"`, path)
+}

--- a/dvm-helper/url/url.go
+++ b/dvm-helper/url/url.go
@@ -1,0 +1,18 @@
+package url
+
+import "strings"
+
+// Join joins any number of path elements into a single path, adding a separating slash if necessary.
+// All empty strings are ignored.
+func Join(elem ...string) string {
+	for i, e := range elem {
+		if e != "" {
+			return clean(strings.Join(elem[i:], "/"))
+		}
+	}
+	return ""
+}
+
+func clean(urlPart string) string {
+	return strings.TrimRight(urlPart, "/")
+}

--- a/dvm-helper/util.go
+++ b/dvm-helper/util.go
@@ -1,0 +1,107 @@
+package main
+
+import "fmt"
+import "io"
+import "net/http"
+import "os"
+import "path/filepath"
+import "github.com/fatih/color"
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func ensureParentDirectoryExists(filePath string) {
+	dir := filepath.Dir(filePath)
+
+	err := os.MkdirAll(dir, 0777)
+	if err != nil {
+		die("Unable to create directory %s.", err, retCodeRuntimeError, dir)
+	}
+}
+
+func downloadFile(url string, destPath string) {
+	ensureParentDirectoryExists(destPath)
+
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		die("Unable to create to %s.", err, retCodeRuntimeError, destPath)
+	}
+	defer destFile.Close()
+	os.Chmod(destPath, 0755)
+
+	writeDebug("Downloading %s", url)
+
+	response, err := http.Get(url)
+	if err != nil {
+		die("Unable to download %s.", err, retCodeRuntimeError, url)
+	}
+
+	if response.StatusCode != 200 {
+		die("Unable to download %s. (Status %d)", nil, retCodeRuntimeError, url, response.StatusCode)
+	}
+	defer response.Body.Close()
+
+	_, err = io.Copy(destFile, response.Body)
+	if err != nil {
+		die("Unable to write to %s.", err, retCodeRuntimeError, destPath)
+	}
+}
+
+func writeFile(path string, contents string) {
+	writeDebug("Writing to %s...", path)
+	writeDebug(contents)
+
+	ensureParentDirectoryExists(path)
+
+	file, err := os.Create(path)
+	if err != nil {
+		die("Unable to create %s", err, retCodeRuntimeError, path)
+	}
+
+	_, err = io.WriteString(file, contents)
+	if err != nil {
+		die("Unable to write to %s", err, retCodeRuntimeError, path)
+	}
+
+	file.Close()
+}
+
+func writeDebug(format string, a ...interface{}) {
+	if !debug {
+		return
+	}
+
+	color.Cyan(format, a...)
+}
+
+func writeInfo(format string, a ...interface{}) {
+	if silent {
+		return
+	}
+
+	color.White(format, a...)
+}
+
+func writeWarning(format string, a ...interface{}) {
+	if silent {
+		return
+	}
+
+	color.Yellow(format, a...)
+}
+
+func writeError(format string, err error, a ...interface{}) {
+	color.Set(color.FgRed)
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	color.Unset()
+}
+
+func die(format string, err error, exitCode int, a ...interface{}) {
+	writeError(format, err, a...)
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
Fixes #44. On mac/linux it updates the running binary. On windows it downloads the binary and the wrapper script copies it.

`dvm upgrade` installs the latest version
`dvm upgrade --check` checks for a new version but does not make any changes.
`dvm upgrade --version <version>` installs the specified version.