### PR TITLE
Bash completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,29 @@ If you want to see what versions are available to install:
 To restore your PATH, you can deactivate it:
 
     dvm deactivate
+
+## Bash and zsh completion
+
+There is bash and zsh completion available in `$DVM_DIR/bash_completion`. To invoke it into your shell, run
+
+```bash
+[[ -r $DVM_DIR/bash_completion ]] && . $DVM_DIR/bash_completion
+```
+
+For zsh, there's a bit of special sauce using `bashcompinit` from the more recent versions of zsh.
+
+### Usage
+
+```
+$ dvm [TAB]
+alias        install      ls           uninstall    which
+current      list         ls-alias     unload
+deactivate   list-alias   ls-remote    use
+help         list-remote  unalias      version
+$ dvm u[TAB]
+unalias    uninstall  unload     use
+$ dvm us[TAB]
+$ dvm use [TAB]
+1.8.2         1.9.0         carina        default       experimental
+```
+

--- a/bash_completion
+++ b/bash_completion
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# bash completion for Docker Version Manager (DVM)
+
+__dvm_generate_completion()
+{
+  declare current_word
+  current_word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$1" -- "$current_word"))
+  return 0
+}
+
+__dvm_commands ()
+{
+  declare current_word
+  declare command
+
+  current_word="${COMP_WORDS[COMP_CWORD]}"
+
+  COMMANDS='\
+    help install uninstall use \
+    alias unalias \
+    current list ls list-remote ls-remote \
+    deactivate unload \
+    version which'
+
+    if [ ${#COMP_WORDS[@]} == 4 ]; then
+
+      command="${COMP_WORDS[COMP_CWORD-2]}"
+      case "${command}" in
+      alias)  __dvm_installed_dockers ;;
+      esac
+
+    else
+
+      case "${current_word}" in
+      -*)     __dvm_options ;;
+      *)      __dvm_generate_completion "$COMMANDS" ;;
+      esac
+
+    fi
+}
+
+__dvm_options ()
+{
+  OPTIONS=''
+  __dvm_generate_completion "$OPTIONS"
+}
+
+__dvm_installed_dockers ()
+{
+  __dvm_generate_completion "$(dvm_ls) $(__dvm_aliases)"
+}
+
+__dvm_aliases ()
+{
+  declare aliases
+  aliases=""
+  if [ -d $DVM_DIR/alias ]; then
+    aliases="`cd $DVM_DIR/alias && command ls`"
+  fi
+  echo "${aliases}"
+}
+
+__dvm_alias ()
+{
+  __dvm_generate_completion "$(__dvm_aliases)"
+}
+
+__dvm ()
+{
+  declare previous_word
+  previous_word="${COMP_WORDS[COMP_CWORD-1]}"
+
+  case "$previous_word" in
+  use|ls|list|uninstall) __dvm_installed_dockers ;;
+  alias|unalias)  __dvm_alias ;;
+  *)              __dvm_commands ;;
+  esac
+
+  return 0
+}
+
+# complete is a bash builtin, but recent versions of ZSH come with a function
+# called bashcompinit that will create a complete in ZSH. If the user is in
+# ZSH, load and run bashcompinit before calling the complete function.
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
+complete -o default -o nospace -F __dvm dvm

--- a/bash_completion
+++ b/bash_completion
@@ -21,7 +21,7 @@ __dvm_commands ()
     help install uninstall use \
     alias unalias \
     current list ls list-remote ls-remote \
-    deactivate unload \
+    list-alias ls-alias deactivate unload \
     version which'
 
     if [ ${#COMP_WORDS[@]} == 4 ]; then
@@ -49,7 +49,17 @@ __dvm_options ()
 
 __dvm_installed_dockers ()
 {
-  __dvm_generate_completion "$(dvm_ls) $(__dvm_aliases)"
+  __dvm_generate_completion "$(__dvm_ls) $(__dvm_aliases)"
+}
+
+__dvm_ls ()
+{
+  declare installed
+  installed=""
+  if [ -d $DVM_DIR/bin/docker ]; then
+    installed="`cd $DVM_DIR/bin/docker && command ls`"
+  fi
+  echo "${installed}"
 }
 
 __dvm_aliases ()

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,9 @@ fi
 echo "Downloading dvm.sh..."
 dvm_download -L --progress-bar https://download.getcarina.com/dvm/latest/dvm.sh -o $DVM_DIR/dvm.sh
 
+echo "Downloading bash_completion"
+dvm_download -L --progress-bar https://download.getcarina.com/dvm/latest/bash_completion -o $DVM_DIR/bash_completion
+
 echo "Downloading dvm-helper..."
 install_dvm_helper
 


### PR DESCRIPTION
Bring back that bash and zsh completion.

This uses a custom written `__dvm_ls` instead of using `dvm-helper ls` because we need the output clean. Otherwise we end up with this fun output:

```bash
$ dvm use[TAB]
(1.10.0-dev,  ->            1.8.2         carina        experimental
(1.9.0)       0cdc96c)      build         default       system
```

At any rate, we're back!

```bash
$ dvm [TAB]
alias        install      ls           uninstall    which
current      list         ls-alias     unload
deactivate   list-alias   ls-remote    use
help         list-remote  unalias      version
$ dvm u[TAB]
unalias    uninstall  unload     use
$ dvm us[TAB]
$ dvm use [TAB]
1.8.2         1.9.0         carina        default       experimental
```