### PR TITLE
Add `linux32` to `cross-build` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ get-deps:
 #	eval "$( ./dvm-helper --bash-completion )"
 #	./dvm-helper --version
 
-cross-build: clean get-deps dvm-helper linux darwin windows
+cross-build: clean get-deps dvm-helper linux linux32 darwin windows
 	cp dvm.sh dvm.ps1 dvm.cmd install.sh install.ps1 README.md LICENSE  $(BINDIR)/
 	find $(BINDIR) -maxdepth 1 -name "install.*" -exec sed -i -e 's/latest/$(VERSION)/g' {} \;
 	cp -R $(BINDIR) bin/dvm/latest


### PR DESCRIPTION
A recent patch (14d3ecbbb04aa90fcb34907a275999d28aca20d4) added a target
for Linux 32 bit support, but without adding `linux32` to the
`cross-build`, nothing actually happens.

This patch should close the loop on that.

This is a follow-up to https://github.com/getcarina/dvm/pull/69 and should resolve https://github.com/getcarina/dvm/issues/68.