### PR TITLE
Make dvm use and dvm list <pattern> play nice

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -211,6 +211,7 @@ func current() {
 }
 
 func list(pattern string) {
+	pattern += "*"
 	versions := getInstalledVersions(pattern)
 	current, _ := getCurrentDockerVersion()
 
@@ -572,7 +573,7 @@ func listRemote(pattern string) {
 }
 
 func getInstalledVersions(pattern string) []string {
-	versions, _ := filepath.Glob(getVersionDir(pattern + "*"))
+	versions, _ := filepath.Glob(getVersionDir(pattern))
 
 	var results []string
 	for _, versionDir := range versions {


### PR DESCRIPTION
dvm list 1.9 should return all versions starting with 1.9.
dvm use 1.9 should check if 1.9 is installed without wildcards

Fixes #77 