### PR TITLE
Fix regression where system didn't show in ls

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -15,6 +15,7 @@ import "github.com/getcarina/dvm/dvm-helper/url"
 import "github.com/google/go-github/github"
 import "github.com/codegangsta/cli"
 import "github.com/kardianos/osext"
+import "github.com/ryanuber/go-glob"
 import "golang.org/x/oauth2"
 
 // These are global command line variables
@@ -595,7 +596,7 @@ func getInstalledVersions(pattern string) []string {
 		results = append(results, version)
 	}
 
-	if pattern == "" || pattern == "system" {
+	if glob.Glob(pattern, "system") {
 		systemVersion, err := getSystemDockerVersion()
 		if err == nil {
 			results = append(results, fmt.Sprintf("system (%s)", systemVersion))


### PR DESCRIPTION
I was previously using a hand-rolled check in `dvm ls` for when we should display `system`. Since pattern can be any globbing pattern, I've switched to using globs to check if system matches, and should be displayed.

Fixes #81 