### PR TITLE
use literal tab

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,6 @@ echo ""
 echo "Docker Version Manager (dvm) has been installed to ${DVM_DIR}"
 echo "Run the following command to start using dvm. Then add it to your bash profile (e.g. ~/.bashrc or ~/.bash_profile) to complete the installation."
 echo ""
-echo "\tsource ${DVM_DIR}/dvm.sh"
+echo "  source ${DVM_DIR}/dvm.sh"
 
 }


### PR DESCRIPTION
Despite the misleading github syntax highlighting, "\t" is not a valid escape syntax for "echo", so dvm tells you to actually type "\tsource" which is not a command on my system :).