### PR TITLE
Race condition when removing "$DVM_DIR/.tmp/dvm-output.sh"

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -33,10 +33,7 @@ dvm() {
     return 1
   fi
 
-  DVM_OUTPUT="$DVM_DIR/.tmp/dvm-output.sh"
-  if [ -e $DVM_OUTPUT ]; then
-    rm $DVM_OUTPUT
-  fi
+  rm -f "$DVM_DIR/.tmp/dvm-output.sh"
 
   DVM_DIR=$DVM_DIR $DVM_DIR/dvm-helper/dvm-helper --shell sh $@
 


### PR DESCRIPTION
I run `dvm use` in my `.zshrc`. If I open multiple windows at once there seems to be a race condition when deleting this file. This seems to fix it.

Thanks for dvm!