### PR TITLE
Enable scripts to call the dvm function

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -43,4 +43,5 @@ dvm() {
   fi
 }
 
+export -f dvm
 }


### PR DESCRIPTION
1. source dvm.sh, I do this in my bash_profile
2. write a script that uses dvm
3. call the script. Currently, it fails because it can't find the dvm function

The proposed change makes the above scenario work.