### PR TITLE
Handle archived Docker releases

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -50,6 +50,11 @@ func (version *Version) SetAsExperimental() {
 	version.Alias = ExperimentalAlias
 }
 
+func (version Version) ShouldUseArchivedRelease() bool {
+	cutoff := semver.MustParse("1.11.0")
+	return !version.IsExperimental() && version.SemVer.GTE(cutoff)
+}
+
 func (version Version) String() string {
 	if version.HasAlias() {
 		if version.HasSemVer() {

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -5,6 +5,7 @@ package main
 import "path/filepath"
 
 const binaryFileExt string = ""
+const archiveFileExt string = ".tgz"
 
 func upgradeSelf(version string) {
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -9,6 +9,7 @@ import "strings"
 const dockerOS string = "Windows"
 const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
+const archiveFileExt string = ".zip"
 
 func upgradeSelf(version string) {
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")


### PR DESCRIPTION
`dvm install` checks the version being installed and `version >= 1.11.0`, it first downloads the archive, and then extracts the binary from it. Experimental releases are still shipped the same as before, so we can continue to get the experimental docker client by hitting the experimental mirror and downloading `docker-latest`.

Closes #95