### PR TITLE
Handle spaces in $DVM_DIR path

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -23,7 +23,7 @@ if [ -z "$DVM_DIR" ]; then
   if [ -n "$BASH_SOURCE" ]; then
     DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
   fi
-  export DVM_DIR="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && \pwd)"
+  export DVM_DIR="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)"
 fi
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 

--- a/dvm.sh
+++ b/dvm.sh
@@ -23,7 +23,7 @@ if [ -z "$DVM_DIR" ]; then
   if [ -n "$BASH_SOURCE" ]; then
     DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
   fi
-  export DVM_DIR=$(cd $DVM_CD_FLAGS $(dirname "${DVM_SCRIPT_SOURCE:-$0}") > /dev/null && \pwd)
+  export DVM_DIR="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && \pwd)"
 fi
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 


### PR DESCRIPTION
Ran across these bugs while looking into #101; this `sh` source was a little broken, so I touched it up. (=