### PR TITLE
fix dvm.sh under zsh

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -43,5 +43,9 @@ dvm() {
   fi
 }
 
-export -f dvm
+if [ -n "$ZSH_NAME" ]; then
+  autoload dvm
+else
+  export -f dvm
+fi
 }


### PR DESCRIPTION
Using export -f func under zsh will print the function body to console, so use autoload seems better for this case.