### PR TITLE
Option to pick a local mirror for Docker binaries

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -294,10 +294,12 @@ func install(version dockerversion.Version) {
 }
 
 func buildDownloadURL(version dockerversion.Version) string {
-  mirrorURL := os.Getenv("MIRROR_URL")
-  if mirrorURL == "" {
-	  mirrorURL := "https://get.docker.com/builds"
-  }
+	tmpURL := os.Getenv("MIRROR_URL")
+	if tmpURL == "" {
+		mirrorURL := "https://get.docker.com/builds"
+	} else {
+		mirrorURL := tmpURL
+	}
 	dockerVersion := version.SemVer.String()
 	if version.IsExperimental() {
 		writeDebug("Downloading from experimental builds mirror")

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -295,7 +295,7 @@ func install(version dockerversion.Version) {
 
 func buildDownloadURL(version dockerversion.Version) string {
   mirrorURL := os.Getenv("MIRROR_URL")
-  if mirrorURL == "" {}
+  if mirrorURL == "" {
 	  mirrorURL := "https://get.docker.com/builds"
   }
 	dockerVersion := version.SemVer.String()

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -294,11 +294,9 @@ func install(version dockerversion.Version) {
 }
 
 func buildDownloadURL(version dockerversion.Version) string {
-	tmpURL := os.Getenv("MIRROR_URL")
-	if tmpURL == "" {
-		mirrorURL := "https://get.docker.com/builds"
-	} else {
-		mirrorURL := tmpURL
+	mirrorURL := os.Getenv("MIRROR_URL")
+	if mirrorURL == "" {
+		mirrorURL = "https://get.docker.com/builds"
 	}
 	dockerVersion := version.SemVer.String()
 	if version.IsExperimental() {

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -294,7 +294,10 @@ func install(version dockerversion.Version) {
 }
 
 func buildDownloadURL(version dockerversion.Version) string {
-	mirrorURL := "https://get.docker.com/builds"
+  mirrorURL := os.Getenv("MIRROR_URL")
+  if mirrorURL == "" {}
+	  mirrorURL := "https://get.docker.com/builds"
+  }
 	dockerVersion := version.SemVer.String()
 	if version.IsExperimental() {
 		writeDebug("Downloading from experimental builds mirror")


### PR DESCRIPTION
Those among us doomed to deal with corporate proxies might be able to download binaries to a local mirror or use something like Artifactory.

Suggestion: "dvm" would accept a MIRROR_URL environment variable that points to another place where the Docker binaries were previously downloaded.