### PR TITLE
Use releases

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -662,7 +662,7 @@ func getInstalledVersions(pattern string) []dockerversion.Version {
 
 func getAvailableVersions(pattern string) []dockerversion.Version {
 	gh := buildGithubClient()
-	tags, response, err := gh.Repositories.ListTags("docker", "docker", nil)
+	releases, response, err := gh.Repositories.ListReleases("docker", "docker", nil)
 	if err != nil {
 		warnWhenRateLimitExceeded(err, response)
 		die("Unable to retrieve list of Docker tags from GitHub", err, retCodeRuntimeError)
@@ -678,8 +678,8 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 	}
 
 	var results []dockerversion.Version
-	for _, tag := range tags {
-		version := *tag.Name
+	for _, release := range releases {
+		version := *release.Name
 		match := versionRegex.FindStringSubmatch(version)
 		if len(match) > 1 && patternRegex.MatchString(version) {
 			results = append(results, dockerversion.Parse(match[1]))

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -662,7 +662,7 @@ func getInstalledVersions(pattern string) []dockerversion.Version {
 
 func getAvailableVersions(pattern string) []dockerversion.Version {
 	gh := buildGithubClient()
-	options := &github.ListOptions{PerPage: 10}
+	options := &github.ListOptions{PerPage: 100}
 
 	var allReleases []github.RepositoryRelease
 	for {

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -662,14 +662,25 @@ func getInstalledVersions(pattern string) []dockerversion.Version {
 
 func getAvailableVersions(pattern string) []dockerversion.Version {
 	gh := buildGithubClient()
-	releases, response, err := gh.Repositories.ListReleases("docker", "docker", nil)
-	if err != nil {
-		warnWhenRateLimitExceeded(err, response)
-		die("Unable to retrieve list of Docker tags from GitHub", err, retCodeRuntimeError)
+	options := &github.ListOptions{PerPage: 10}
+
+	var allReleases []github.RepositoryRelease
+	for {
+		releases, response, err := gh.Repositories.ListReleases("docker", "docker", options)
+		if err != nil {
+			warnWhenRateLimitExceeded(err, response)
+			die("Unable to retrieve list of Docker releases from GitHub", err, retCodeRuntimeError)
+		}
+		allReleases = append(allReleases, releases...)
+		if response.StatusCode != 200 {
+			die("Unable to retrieve list of Docker releases from GitHub (Status %s).", nil, retCodeRuntimeError, response.StatusCode)
+		}
+		if response.NextPage == 0 {
+			break
+		}
+		options.Page = response.NextPage
 	}
-	if response.StatusCode != 200 {
-		die("Unable to retrieve list of Docker tags from GitHub (Status %s).", nil, retCodeRuntimeError, response.StatusCode)
-	}
+
 
 	versionRegex := regexp.MustCompile(`^v([1-9]+\.\d+\.\d+)$`)
 	patternRegex, err := regexp.Compile(pattern)
@@ -678,7 +689,7 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 	}
 
 	var results []dockerversion.Version
-	for _, release := range releases {
+	for _, release := range allReleases {
 		version := *release.Name
 		match := versionRegex.FindStringSubmatch(version)
 		if len(match) > 1 && patternRegex.MatchString(version) {


### PR DESCRIPTION
 Tags appear to be limited to the last X number of valid tags (not sure what X is.) Sadly, I still need to use 1.8.3 for some systems, but it is now past the X cutoff. This allows you to use any release vs using tags