### PR TITLE
Do not assume that install dir and home dir are the same

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -1,23 +1,25 @@
 package main
 
-import "errors"
-import "fmt"
-import "io/ioutil"
-import "os"
-import "os/exec"
-import "path"
-import "path/filepath"
-import "regexp"
-import "strings"
-import "github.com/blang/semver"
-import "github.com/fatih/color"
-import "github.com/getcarina/dvm/dvm-helper/url"
-import "github.com/getcarina/dvm/dvm-helper/dockerversion"
-import "github.com/google/go-github/github"
-import "github.com/codegangsta/cli"
-import "github.com/kardianos/osext"
-import "github.com/ryanuber/go-glob"
-import "golang.org/x/oauth2"
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/codegangsta/cli"
+	"github.com/fatih/color"
+	"github.com/getcarina/dvm/dvm-helper/dockerversion"
+	"github.com/getcarina/dvm/dvm-helper/url"
+	"github.com/google/go-github/github"
+	"github.com/ryanuber/go-glob"
+	"golang.org/x/oauth2"
+)
 
 // These are global command line variables
 var shell string
@@ -46,7 +48,7 @@ func main() {
 	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "github-token", EnvVar: "GITHUB_TOKEN", Usage: "Increase the github api rate limit by specifying your github personal access token."},
-		cli.StringFlag{Name: "dvm-dir", EnvVar: "DVM_DIR", Usage: "Specify an alternate DVM home directory, defaults to the current directory."},
+		cli.StringFlag{Name: "dvm-dir", EnvVar: "DVM_DIR", Usage: "Specify an alternate DVM home directory, defaults to $HOME/.dvm."},
 		cli.StringFlag{Name: "shell", EnvVar: "SHELL", Usage: "Specify the shell format in which environment variables should be output, e.g. powershell, cmd or sh/bash. Defaults to sh/bash."},
 		cli.BoolFlag{Name: "debug", Usage: "Print additional debug information."},
 		cli.BoolFlag{Name: "silent", EnvVar: "DVM_SILENT", Usage: "Suppress output. Errors will still be displayed."},
@@ -211,12 +213,9 @@ func setGlobalVars(c *cli.Context) {
 
 	dvmDir = c.GlobalString("dvm-dir")
 	if dvmDir == "" {
-		var err error
-		dvmDir, err = osext.ExecutableFolder()
-		if err != nil {
-			die("Unable to determine DVM home directory", nil, 1)
-		}
+		dvmDir = filepath.Join(getUserHomeDir(), ".dvm")
 	}
+	writeDebug("The dvm home directory is: %s", dvmDir)
 }
 
 func upgrade(checkOnly bool, version string) {
@@ -702,7 +701,6 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 		}
 		options.Page = response.NextPage
 	}
-
 
 	versionRegex := regexp.MustCompile(`^v([1-9]+\.\d+\.\d+)$`)
 	patternRegex, err := regexp.Compile(pattern)

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -48,7 +48,7 @@ func main() {
 	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "github-token", EnvVar: "GITHUB_TOKEN", Usage: "Increase the github api rate limit by specifying your github personal access token."},
-		cli.StringFlag{Name: "dvm-dir", EnvVar: "DVM_DIR", Usage: "Specify an alternate DVM home directory, defaults to $HOME/.dvm."},
+		cli.StringFlag{Name: "dvm-dir", EnvVar: "DVM_DIR", Usage: "Specify an alternate DVM home directory, defaults to ~/.dvm."},
 		cli.StringFlag{Name: "shell", EnvVar: "SHELL", Usage: "Specify the shell format in which environment variables should be output, e.g. powershell, cmd or sh/bash. Defaults to sh/bash."},
 		cli.BoolFlag{Name: "debug", Usage: "Print additional debug information."},
 		cli.BoolFlag{Name: "silent", EnvVar: "DVM_SILENT", Usage: "Suppress output. Errors will still be displayed."},

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -2,7 +2,10 @@
 
 package main
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
 
 const binaryFileExt string = ""
 const archiveFileExt string = ".tgz"
@@ -24,4 +27,8 @@ func getCleanPathRegex() string {
 
 func validateShellFlag() {
 	// we don't care about the shell flag on non-Windows platforms
+}
+
+func getUserHomeDir() string {
+	return os.Getenv("HOME")
 }

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "fmt"
-import "path/filepath"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
 import "strings"
 
 const dockerOS string = "Windows"
@@ -52,4 +55,8 @@ func validateShellFlag() {
 	if shell != "powershell" && shell != "cmd" {
 		die("The --shell flag or SHELL environment variable must be set when running on Windows. Available values are powershell and cmd.", nil, retCodeInvalidArgument)
 	}
+}
+
+func getUserHomeDir() string {
+	return os.Getenv("USERPROFILE")
 }

--- a/dvm.ps1
+++ b/dvm.ps1
@@ -3,7 +3,10 @@
 # To use, source this script, `. dvm.ps1`, then type dvm help
 
 function dvm() {
-  $dvmDir = $PSScriptRoot
+  $dvmDir = $env:DVM_DIR
+  if( $dvmDir -eq $null ) {
+    $dvmDir = "$env:USERPROFILE\.dvm"
+  }
 
   if( !(Test-Path (Join-Path $dvmDir dvm-helper\dvm-helper.exe)) ) {
     $host.ui.WriteErrorLine("Installation corrupt: dvm-helper.exe is missing. Please reinstall dvm.")

--- a/dvm.ps1
+++ b/dvm.ps1
@@ -3,25 +3,27 @@
 # To use, source this script, `. dvm.ps1`, then type dvm help
 
 function dvm() {
+  # Default dvm home to ~/.dvm if not set
   $dvmDir = $env:DVM_DIR
   if( $dvmDir -eq $null ) {
     $dvmDir = "$env:USERPROFILE\.dvm"
   }
 
-  if( !(Test-Path (Join-Path $dvmDir dvm-helper\dvm-helper.exe)) ) {
+  # Expect that dvm-helper is next to this script
+  $dvmHelper = Join-Path $PSScriptRoot dvm-helper\dvm-helper.exe
+  if( !(Test-Path $dvmHelper) ) {
     $host.ui.WriteErrorLine("Installation corrupt: dvm-helper.exe is missing. Please reinstall dvm.")
     return 1
   }
 
+  # Pass dvm-helper output back to script via ~/.dvm/.tmp/dvm-output.ps1
   $dvmOutput = Join-Path $dvmDir .tmp\dvm-output.ps1
   if( Test-Path $dvmOutput ) {
     rm $dvmOutput
   }
 
-  $env:DVM_DIR = $dvmDir
-
   $rawArgs = $MyInvocation.Line.Substring(3).Trim()
-  $dvmCall = "$dvmDir\dvm-helper\dvm-helper.exe --shell powershell $rawArgs"
+  $dvmCall = "$dvmHelper --shell powershell $rawArgs"
   iex $dvmCall
 
   if( Test-Path $dvmOutput ) {

--- a/dvm.sh
+++ b/dvm.sh
@@ -18,14 +18,10 @@ if __dvm_has "unsetopt"; then
   DVM_CD_FLAGS="-q"
 fi
 
-# Auto detect the DVM_DIR when not set
+# Default DVM_DIR to $HOME/.dvm when not set
 if [ -z "$DVM_DIR" ]; then
-  if [ -n "$BASH_SOURCE" ]; then
-    DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
-  fi
-  export DVM_DIR="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)"
+  DVM_DIR="$HOME/.dvm"
 fi
-unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 dvm() {
   if [ ! -f "$DVM_DIR/dvm-helper/dvm-helper" ]; then

--- a/dvm.sh
+++ b/dvm.sh
@@ -23,22 +23,32 @@ if [ -z "$DVM_DIR" ]; then
   DVM_DIR="$HOME/.dvm"
 fi
 
+# Expect that dvm-helper is next to this script
+if [ -n "$BASH_SOURCE" ]; then
+  DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+fi
+export DVM_HELPER="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+unset DVM_SCRIPT_SOURCE 2> /dev/null
+
 dvm() {
-  if [ ! -f "$DVM_DIR/dvm-helper/dvm-helper" ]; then
+  if [ ! -f "$DVM_HELPER" ]; then
     echo "Installation corrupt: dvm-helper is missing. Please reinstall dvm."
     return 1
   fi
 
+  # Pass dvm-helper output back to script via ~/.dvm/.tmp/dvm-output.sh
   DVM_OUTPUT="$DVM_DIR/.tmp/dvm-output.sh"
   rm -f "$DVM_OUTPUT"
 
-  DVM_DIR=$DVM_DIR $DVM_DIR/dvm-helper/dvm-helper --shell sh $@
+  $DVM_HELPER --shell sh $@
 
+  # Execute any dvm-helper output
   if [ -e $DVM_OUTPUT ]; then
     source $DVM_OUTPUT
   fi
 }
 
+# Make the dvm function available to other scripts
 if [ -n "$ZSH_NAME" ]; then
   autoload dvm
 else


### PR DESCRIPTION
Support home-brew installations where the installation directory is `/usr/local/opt/dvm` (containing dvm.sh and the dvm-helper binary) while the dvm home directory is located at `~/.dvm` (containing temp files and docker binaries).

This is some legwork to prepare for distributing dvm via homebrew. See https://github.com/getcarina/dvm/issues/85#issuecomment-225044152 for context as to why we want that.