### PR TITLE
Conditionally disable the upgrade command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ VERSION = $(shell git describe --tags --dirty='-dev' 2> /dev/null)
 GITHUB_ORG = getcarina
 GITHUB_REPO = dvm
 PACKAGE = github.com/${GITHUB_ORG}/${GITHUB_REPO}/dvm-helper
+UPGRADE_DISABLED = false
 
-LDFLAGS = -w -X main.dvmCommit=${COMMIT} -X main.dvmVersion=${VERSION}
+LDFLAGS = -w -X main.dvmCommit=${COMMIT} -X main.dvmVersion=${VERSION} -X main.upgradeDisabled=${UPGRADE_DISABLED}
 
 GOCMD = go
 GOBUILD = $(GOCMD) build -a -tags netgo -ldflags '$(LDFLAGS)'

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -33,6 +33,7 @@ var token string
 // These are set during the build
 var dvmVersion string
 var dvmCommit string
+var upgradeDisabled string // Allow package managers like homebrew to disable in-place upgrades
 
 const (
 	retCodeInvalidArgument  = 127
@@ -183,7 +184,10 @@ func main() {
 				return nil
 			},
 		},
-		{
+	}
+
+	if upgradeDisabled != "true" {
+		app.Commands = append(app.Commands, cli.Command{
 			Name:  "upgrade",
 			Usage: "dvm upgrade\n\tUpgrade dvm to the latest release.",
 			Flags: []cli.Flag{
@@ -195,7 +199,7 @@ func main() {
 				upgrade(c.Bool("check"), c.String("version"))
 				return nil
 			},
-		},
+		})
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
Builds for package managers have upgrade disabled, so that in-place upgrades don't screw up their chocolatey/homebrew installation.

This is hopefully the last step to prepare dvm to be distributed via a package manager like homebrew or chocolatey. See #85.