### PR TITLE
Use glide to manage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/vendor
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 go:
   - 1.5
-install: make get-deps
+install:
+  - go get github.com/Masterminds/glide
+  - make get-deps
 script: make cross-build
 before_deploy:
   - cd bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.6
 install:
   - go get github.com/Masterminds/glide
   - make get-deps

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOFILES = dvm-helper/*.go
 default: dvm-helper
 
 get-deps:
-	go get ./...
+	glide install
 
 #test: dvm-helper
 #	go test -v

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,54 @@
+hash: e3539f5d2fb6f53cc816cd79bc4a2c8f76e595f4f25b182ae8a5eb863753ad17
+updated: 2016-06-27T11:02:45.626128223-05:00
+imports:
+- name: github.com/blang/semver
+  version: e64c75d1c910cd81c8caa1f2cc2c6409dd65af81
+- name: github.com/codegangsta/cli
+  version: 4205e9c4ee9672a8df5bb4fe486a8aa07e1e4037
+- name: github.com/fatih/color
+  version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
+- name: github.com/golang/protobuf
+  version: 0c1f6d65b5a189c2250d10e71a5506f06f9fa0a0
+  subpackages:
+  - proto
+- name: github.com/google/go-github
+  version: 1c08387e4c91df86627d0853f155a4efc8cb8a2d
+  subpackages:
+  - github
+- name: github.com/google/go-querystring
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  subpackages:
+  - query
+- name: github.com/mattn/go-colorable
+  version: 9056b7a9f2d1f2d96498d6d146acd1f9d5ed3d59
+- name: github.com/mattn/go-isatty
+  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
+- name: github.com/pivotal-golang/archiver
+  version: f598990ddfeda2767a09346acf844a7d216c1256
+  subpackages:
+  - extractor
+- name: github.com/ryanuber/go-glob
+  version: 572520ed46dbddaed19ea3d9541bdd0494163693
+- name: golang.org/x/net
+  version: e445b19913b9d40fdbdfe19ac5e3d314aafd6f63
+  subpackages:
+  - context
+- name: golang.org/x/oauth2
+  version: 65a8d08c6292395d47053be10b3c5e91960def76
+  subpackages:
+  - internal
+- name: golang.org/x/sys
+  version: 62bee037599929a6e9146f29d10dd5208c43507d
+  subpackages:
+  - unix
+- name: google.golang.org/appengine
+  version: 267c27e7492265b84fc6719503b14a1e17975d79
+  subpackages:
+  - urlfetch
+  - internal
+  - internal/urlfetch
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: github.com/getcarina/dvm
+import:
+- package: github.com/blang/semver
+- package: github.com/codegangsta/cli
+- package: github.com/fatih/color
+- package: github.com/pivotal-golang/archiver
+  subpackages:
+  - extractor
+- package: github.com/ryanuber/go-glob
+- package: golang.org/x/oauth2
+- package: github.com/google/go-github
+  version: 1c08387e4c91df86627d0853f155a4efc8cb8a2d


### PR DESCRIPTION
* At the moment this assumes that glide is on the path (`brew install glide`). 
* I will circle back and improve the "just clone and run make" experience for all platforms if we settle on this path.

Closes #122