### PR TITLE
Use archived binary releases for experimental builds

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -52,7 +52,7 @@ func (version *Version) SetAsExperimental() {
 
 func (version Version) ShouldUseArchivedRelease() bool {
 	cutoff := semver.MustParse("1.11.0")
-	return !version.IsExperimental() && version.SemVer.GTE(cutoff)
+	return version.IsExperimental() || version.SemVer.GTE(cutoff)
 }
 
 func (version Version) String() string {


### PR DESCRIPTION
When the new release format was added (tgz vs. direct binary downloads), experimental builds were still using the old format. Now all experimental builds are archived and this fixes `docker install experimental` which will now correctly download and install docker 1.12-rc4.

Fixes #127.