### PR TITLE
"escape" invoked shell commands

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -27,7 +27,7 @@ fi
 if [ -n "$BASH_SOURCE" ]; then
   DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 fi
-export DVM_HELPER="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+export DVM_HELPER="$(command cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 dvm() {
@@ -38,7 +38,7 @@ dvm() {
 
   # Pass dvm-helper output back to script via ~/.dvm/.tmp/dvm-output.sh
   DVM_OUTPUT="$DVM_DIR/.tmp/dvm-output.sh"
-  rm -f "$DVM_OUTPUT"
+  command rm -f "$DVM_OUTPUT"
 
   $DVM_HELPER --shell sh $@
 


### PR DESCRIPTION
 in addition to c326389 any commands should be called by `command` or `builtin` to avoid any shell script overloads