### PR TITLE
Build with go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6
+  - 1.7
 install:
   - make get-deps
 script: make cross-build


### PR DESCRIPTION
Go 1.7 has a fix to work with Mac OS Sierra's backwards incompatible changes.

Fixes the following runtime error when carina decides if we have checked for updates within the last 24 horus:

```
failed MSpanList_Insert 0x755588 0xcbde9d7ef878 0x0
fatal error: MSpanList_Insert
```